### PR TITLE
Add Buderus MX300 to device_library.h

### DIFF
--- a/src/device_library.h
+++ b/src/device_library.h
@@ -171,6 +171,8 @@
 
 // Gateways - 0x48
 {189, DeviceType::GATEWAY, "KM200/MB LAN 2", DeviceFlags::EMS_DEVICE_FLAG_NONE},
+{252, DeviceType::GATEWAY, "MX300", DeviceFlags::EMS_DEVICE_FLAG_NONE},
+
 
 // Generic - 0x40 or other with no product-id and no version
 {0, DeviceType::GENERIC, "unknown", DeviceFlags::EMS_DEVICE_FLAG_NONE}


### PR DESCRIPTION
As announced in Discord.

This is Buderus MX300 Internet Gateway.


```
{
      "type": "gateway",
      "name": "WiFi module",
      "device id": "0x48",
      "product id": 252,
      "version": "07.02",
      "entities": 0,
      "handlers ignored": "0x2040"
    }
```


If we need anything more please tell me :)